### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	autoconf \
+	camlp4 \
+	g++ \
+	gcc \
+	libbz2-dev \
+	libc6-dev \
+	libgd-gd2-noxpm-ocaml-dev \
+	libmagic-dev \
+	libminiupnpc-dev \
+	libnatpmp-dev \
+	libnum-ocaml-dev \
+	make \
+	ocaml-nox \
+	zlib1g-dev
+
+WORKDIR /app
+COPY . /app
+
+RUN ./configure \
+	--disable-directconnect \
+	--disable-fasttrack \
+	--disable-gnutella \
+	--disable-gnutella2 \
+	--enable-batch \
+	--enable-upnp-natpmp \
+	&& make
+
+FROM ubuntu
+
+RUN adduser --disabled-password --gecos "" mlnet
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	ca-certificates \
+	libgd3 \
+	libmagic1 \
+	libminiupnpc17 \
+	libnatpmp1 \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/mlnet /usr/bin/
+
+USER mlnet
+ENTRYPOINT ["/usr/bin/mlnet"]

--- a/README.md
+++ b/README.md
@@ -2,4 +2,22 @@
 
 ![Build](https://github.com/ygrek/mldonkey/workflows/Build/badge.svg?branch=master)
 
+## Use with Docker
+
+To create a docker image with the latest version for your platform (tested with `amd64` and `aarch64`), checkout this git repo and run:
+
+
+```
+docker build -t mldonkey:latest .
+```
+
+To run the container with docker-compose, edit the docker-compose.yml file to match your network and storage settings. Then run:
+
+```
+docker-compose up
+```
+
+Make sure the user id 1000 has write access to the volume mount point (`/srv/mlnet` in this example).
+
+
 http://mldonkey.sourceforge.net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.3'
+
+services:
+  mldonkey:
+    image: mldonkey
+    command: "--ED2K-port 4662 --BT-dht_port 3615"
+    container_name: mldonkey
+    restart: unless-stopped
+    ports:
+      - "4000:4000"       # Telnet
+      - "4001:4001"       # GUI
+      - "4080:4080"       # Web GUI
+      - "3615:3615/udp"   # BitTorrent DHT
+      - "4662:4662"       # eDonkey TCP
+      - "4666:4666/udp"   # eDonkey UDP (TCP+4)
+      - "6881:6881"       # BitTorrent
+      - "6882:6882"       # BitTorrent
+    volumes:
+      - "/srv/mlnet:/home/mlnet/.mldonkey"
+


### PR DESCRIPTION
This PR add the files needed to run MLDonkey with Docker using Ubuntu base image.

The Dockerfile is a multi-stage build that will compile the latest version of MLDonkey for the user's architecture, but will not bring development tools in the runtime image.
And example of usage is provided with the `docker-compose.yml` file.

Note: This PR require https://github.com/ygrek/mldonkey/pull/64 to be merged to run with docker-compose properly.