### PR TITLE
Fix byte type collision in bundled crypto++ with C++17

### DIFF
--- a/config/configure.in
+++ b/config/configure.in
@@ -1177,8 +1177,7 @@ echo "--------------------------------------"
 	  DONKEY_SUI=no
 	else
 	  AC_MSG_RESULT(yes)
-	  ACX_CHECK_CXX_FLAGS(-std=c++14,cv_stdcxx14, CRYPTOPPFLAGS="-std=c++14")
-	  ACX_CHECK_CXX_FLAGS(-fno-omit-frame-pointer,cv_no_omit_frame_pointer, CRYPTOPPFLAGS="$CRYPTOPPFLAGS -fno-omit-frame-pointer")
+	  ACX_CHECK_CXX_FLAGS(-fno-omit-frame-pointer,cv_no_omit_frame_pointer, CRYPTOPPFLAGS="-fno-omit-frame-pointer")
 	  ACX_CHECK_CXX_FLAGS(-mno-omit-leaf-frame-pointer,cv_no_omit_leaf_frame_pointer, CRYPTOPPFLAGS="$CRYPTOPPFLAGS -mno-omit-leaf-frame-pointer")
 	  CXX=$NEWCXX
 	  CXX_VERSION=`$CXX -dumpversion`

--- a/src/utils/lib/CryptoPP.cc
+++ b/src/utils/lib/CryptoPP.cc
@@ -9482,7 +9482,7 @@ inline void PokeUInt32(void* p, uint32_t nVal)
 #define PRIVKEYSIZE 384
 
 static Signer* s_signer = NULL;   
-static byte m_publicKey[MAXPUBKEYSIZE+1];
+static CryptoPP::byte m_publicKey[MAXPUBKEYSIZE+1];
 static unsigned long m_publicKeyLen = 0;
 
 void cc_lprintf_nl(const char * msg, bool verb);
@@ -9555,7 +9555,7 @@ unsigned long loadKey(char privateKeyBase64[], char buf[]) {
 
 
 // return signatureSize (buf)
-int createSignature(byte *buf, int maxLen, byte *key, int keyLen, uint32_t cInt, uint8_t ipType, uint32_t ip) {
+int createSignature(CryptoPP::byte *buf, int maxLen, CryptoPP::byte *key, int keyLen, uint32_t cInt, uint8_t ipType, uint32_t ip) {
 
 	int result = 0;
 
@@ -9570,7 +9570,7 @@ int createSignature(byte *buf, int maxLen, byte *key, int keyLen, uint32_t cInt,
 		CryptoPP::SecByteBlock sBB(s_signer->SignatureLength());
 		CryptoPP::AutoSeededRandomPool rng;
 	
-		byte bArray[MAXPUBKEYSIZE+9];
+		CryptoPP::byte bArray[MAXPUBKEYSIZE+9];
 
 		memcpy(bArray,key,keyLen);
 		PokeUInt32(bArray+keyLen,cInt);   
@@ -9597,7 +9597,7 @@ int createSignature(byte *buf, int maxLen, byte *key, int keyLen, uint32_t cInt,
 
 }
 
-int verifySignature(byte *key, int keyLen, byte *sig, int sigLen, uint32_t cInt, uint8_t ipType, uint32_t ip) {
+int verifySignature(CryptoPP::byte *key, int keyLen, CryptoPP::byte *sig, int sigLen, uint32_t cInt, uint8_t ipType, uint32_t ip) {
   using namespace CryptoPP;
 
 	bool result = false;
@@ -9607,7 +9607,7 @@ int verifySignature(byte *key, int keyLen, byte *sig, int sigLen, uint32_t cInt,
 		StringSource ss_Pubkey(key, keyLen,true,0);
 		Verifier pubKey(ss_Pubkey);
 
-		byte bArray[MAXPUBKEYSIZE+9];
+		CryptoPP::byte bArray[MAXPUBKEYSIZE+9];
 	
 		memcpy(bArray,m_publicKey,m_publicKeyLen);
 		PokeUInt32(bArray+m_publicKeyLen,cInt); 

--- a/src/utils/lib/CryptoPP.h
+++ b/src/utils/lib/CryptoPP.h
@@ -181,10 +181,9 @@
 #	define __USE_W32_SOCKETS
 #endif
 
-typedef unsigned char byte;		// put in global namespace to avoid ambiguity with other byte typedefs
-
 NAMESPACE_BEGIN(CryptoPP)
 
+typedef unsigned char byte;		// put in global namespace to avoid ambiguity with other byte typedefs
 typedef unsigned short word16;
 typedef unsigned int word32;
 


### PR DESCRIPTION
This fixes the issue mentioned in #62 that C++17 introduces a new `byte` type which conflicts with the one defined by Crypto++.

This was also discussed upstream: https://www.cryptopp.com/wiki/Std::byte

And this patch adopts the same solution as upstream, which is moving their `byte` definition to the `CryptoPP` namespace: https://github.com/weidai11/cryptopp/commit/00f9818b5d8e5aeb6c1057aa395317635bae07a3

Actually, this is basically the same patch.

This PR also reverts #63, as forcing C++14 wouldn't be required anymore and the patch submitted by #63 didn't work for me when I tried to apply it to the Gentoo package (downstream [bug #790134](https://bugs.gentoo.org/790134)).

_(Edit: it was previously said this PR reverts #62, but the actual PR number is #63, which is linked to issue #62)_