### PR TITLE
Fix text color in the dark theme

### DIFF
--- a/src/daemon/common/commonMessages.ml
+++ b/src/daemon/common/commonMessages.ml
@@ -53,6 +53,7 @@ body {
   margin-right: 5px;
   font-family: Verdana, sans-serif;
   font-size: 12px;
+  color: @color_general_text@;
   }
 table.commands {
   border: @color_general_border@ solid 1px;


### PR DESCRIPTION
There are text messages in the web interface that are not included in p tags or other tags. I therefore had to set the font color for the entire body also. This should fix the dark theme and should not break the other themes.