### PR TITLE
Build fix: the compress_string function must be taken from the new Zlib2 module

### DIFF
--- a/src/gtk2/gui/guiArt.ml
+++ b/src/gtk2/gui/guiArt.ml
@@ -241,7 +241,7 @@ open Zlib
 
 (* Return a pixbuf for a given svg data *)
 let pixb icon_name pixel_size =
-  let svg = uncompress_string icon_name in
+  let svg = Zlib2.uncompress_string icon_name in
   let z = float_of_int pixel_size /. 48. in
   let size_cb = (Rsvg.at_zoom z z) in
   let pb = Rsvg.render_from_string ~size_cb svg in

--- a/tools/svg_converter.ml
+++ b/tools/svg_converter.ml
@@ -19,7 +19,7 @@
 
 
 open Filename2
-open Zlib
+open Zlib2
 
 let load_svg file =
   Printf.printf "Converting file %s\n" file;


### PR DESCRIPTION
Build seems to fail since the last commits. The same procedure I used to build mldonkey in 9bb34bc153cf7e08a12753a4e6e5f161b8f5ba2a seems to fail now. This seems to fix it. May be related to 49f1a9a68ecacdb598a4f8fe6124eb2a03e9eaa3.