### PR TITLE
GCC 14: Fix incompatible pointer type in charsetstubs.c

### DIFF
--- a/src/utils/lib/charsetstubs.c
+++ b/src/utils/lib/charsetstubs.c
@@ -1204,7 +1204,7 @@ ml_iconv (iconv_t cd,
           char    **outbuf,
           size_t  *outbytes_left)
 {
-    return iconv (cd, inbuf, inbytes_left, outbuf, outbytes_left);
+    return iconv (cd, (char **)inbuf, inbytes_left, outbuf, outbytes_left);
 }
 
 #ifndef EILSEQ


### PR DESCRIPTION
The `ml_iconv` function in `charsetstubs.c` was passing a `const char **` input buffer to `iconv`, but `iconv` expects a `char **`.

GCC 14 fails when passing that incompatible pointer type:

```
src/utils/lib/charsetstubs.c: In function ‘ml_iconv’:
src/utils/lib/charsetstubs.c:1207:23: error: passing argument 2 of ‘iconv’ from incompatible pointer type [-Wincompatible-pointer-types]
 1207 |     return iconv (cd, inbuf, inbytes_left, outbuf, outbytes_left);
      |                       ^~~~~
      |                       |
      |                       const char **
In file included from src/utils/lib/charsetstubs.c:45:
/usr/include/iconv.h:49:54: note: expected ‘char ** restrict’ but argument is of type ‘const char **’
   49 | extern size_t iconv (iconv_t __cd, char **__restrict __inbuf,
      |                                    ~~~~~~~~~~~~~~~~~~^~~~~~~
```

Downstream bug: https://bugs.gentoo.org/921257