### PR TITLE
Add sysinfo command to the binary protocol

### DIFF
--- a/src/daemon/common/guiDecoding.ml
+++ b/src/daemon/common/guiDecoding.ml
@@ -1326,6 +1326,10 @@ let from_gui (proto : int array) opcode s =
          let num = get_int s 2 in
          GetStats num
 
+    (* introduced with protocol 34 *)
+    | 69 ->
+      GetSysInfo
+
     | _ -> 
         lprintf_nl "FROM GUI:Unknown message %d" opcode; 
         raise FromGuiMessageNotImplemented

--- a/src/daemon/common/guiEncoding.ml
+++ b/src/daemon/common/guiEncoding.ml
@@ -1049,6 +1049,12 @@ let rec to_gui (proto : int array) buf t =
         buf_int buf num;
         buf_list2 proto buf buf_stat_info_list l
 
+    | SysInfo list ->
+      buf_opcode buf 60;
+      buf_list buf (fun buf (s1, s2) ->
+        buf_string buf s1; buf_string buf s2
+        ) list
+
   with e ->
       lprintf "GuiEncoding.to_gui: Exception %s\n"
         (Printexc2.to_string e)
@@ -1265,6 +1271,9 @@ protocol version. Do not send them ? *)
     | GetStats n ->
         buf_opcode buf 68;
         buf_int buf n
+
+    (* introduced with protocol 34 *)
+    | GetSysInfo -> buf_opcode buf 69
 
   with e ->
       lprintf "GuiEncoding.from_gui: Exception %s\n"

--- a/src/daemon/common/guiProto.ml
+++ b/src/daemon/common/guiProto.ml
@@ -29,8 +29,8 @@ type gift_command =
   
 let gui_extension_poll = 1
   
-let to_gui_last_opcode = 59
-let from_gui_last_opcode = 68
+let to_gui_last_opcode = 60
+let from_gui_last_opcode = 69
 let best_gui_version = 41
   
 (* I will try to report all changes to the protocol here: send me patches
@@ -66,6 +66,9 @@ Version 32:
 Version 33:
   CORE -> GUI: message 15 [CLIENT_INFO] encoding and decoding of the field client_release 
 
+Version 34:
+  GUI -> CORE: message GetSysInfo
+  CORE -> GUI: message SysInfo
   *)
   
   
@@ -168,6 +171,9 @@ the messages (it will use the version specified in CoreProtocol instead
 | ServerSetPreferred of (int * bool)
 | GetStats of int
 
+(* Understood by core protocol 34 *)
+| GetSysInfo
+
 type to_gui =
 (* This message is the first message sent by the core *)
 | CoreProtocol of int * int * int
@@ -235,7 +241,8 @@ type to_gui =
 | GiftServerAttach of string * string
 | GiftServerStats of (string * string * string * string) list
 | Stats of int * (string * int * network_stat_info list) list  
-  
+
+| SysInfo of (string * string) list
   
 let string_of_from_gui t = 
   match t with
@@ -315,6 +322,8 @@ let string_of_from_gui t =
   | ServerSetPreferred _ -> "ServerSetPreferred"
   | GetStats _ -> "GetStats"
 
+  | GetSysInfo -> "GetSysInfo"
+
 let string_of_to_gui t =
   match t with
   
@@ -384,6 +393,8 @@ let string_of_to_gui t =
   | GiftServerAttach _ -> "GiftServerAttach"
   | GiftServerStats _ -> "GiftServerStats"
   | Stats _ -> "Stats"
+
+  | SysInfo _ -> "SysInfo"
       
 type gui_record = {
     mutable gui_num : int;


### PR DESCRIPTION
This commit adds the GetSysInfo and SysInfo messages to the TCP protocol to request and return information about the core, the running system, the disk and the ports.

The info are returned as a list of string pairs. Each pair is composed by an ID and a value.