### PR TITLE
Fix segfault trying to lock/unlock the master lock from unregistered …

### DIFF
--- a/src/utils/lib/stubs_c.c
+++ b/src/utils/lib/stubs_c.c
@@ -722,28 +722,18 @@ static int ml_gethostbyname(char *hostname)
     struct hostent h;
     char buffer[NETDB_BUFFER_SIZE];
     int h_errno;
-    enter_blocking_section();
     hp = gethostbyname_r(hostname, &h, buffer, sizeof(buffer), &h_errno);
-    leave_blocking_section();
   }
 #elif HAS_GETHOSTBYNAME_R == 6
   {
     struct hostent h;
     char buffer[NETDB_BUFFER_SIZE];
     int h_errno, rc;
-    enter_blocking_section();
     rc = gethostbyname_r(hostname, &h, buffer, sizeof(buffer), &hp, &h_errno);
-    leave_blocking_section();
     if (rc != 0) hp = NULL;
   }
 #else
-#ifdef GETHOSTBYNAME_IS_REENTRANT
-  enter_blocking_section();
-#endif
   hp = gethostbyname(hostname);
-#ifdef GETHOSTBYNAME_IS_REENTRANT
-  leave_blocking_section();
-#endif
 #endif
 
   if (hp == (struct hostent *) NULL) return 0;


### PR DESCRIPTION
…thread

A thread that was never registered should not call enter_blocking_section or leave_blocking_section, as it cannot hold the master lock. This can cause segfaults in some cases.