### PR TITLE
Ensure temporary files are given legal filenames

### DIFF
--- a/src/utils/net/http_client.ml
+++ b/src/utils/net/http_client.ml
@@ -436,7 +436,7 @@ let wget r f =
       
       let base = Filename.basename r.req_url.Url.short_file in
       (* Base could be "." for http://site.com/ *)
-      let base = if base = "." 
+      let base = if base = "." || base = "/"
         then begin
           let prng = Random.State.make_self_init () in
           let rnd = (Random.State.bits prng) land 0xFFFFFF in


### PR DESCRIPTION
The short_file value for some URLs may result in the string "/". For example, this URL:

http://te-home.net/?do=hublist&get=hublist.config.bz2

results in:

short_file: /
full_file: /?do=hublist&get=hublist.config.bz2

this makes it impossible to save the file. With this change, a random file name is chosen.