### PR TITLE
File details: use human sizes where appropriate

### DIFF
--- a/src/daemon/common/commonFile.ml
+++ b/src/daemon/common/commonFile.ml
@@ -732,8 +732,9 @@ let file_print file o =
       Printf.bprintf buf "\\</tr\\>\\<tr class=\\\"dl-%d\\\"\\>" (html_mods_cntr ());
       html_mods_td buf [
         ("Downloaded/Total size", "sr br", "DLed/Size");
-        ("", "sr", Printf.sprintf "%s bytes of %s bytes"
-            (Int64.to_string info.G.file_downloaded) (Int64.to_string info.G.file_size) ) ];
+        ("", "sr", Printf.sprintf "%s of %s bytes"
+            (if !!html_mods_human_readable then (size_of_int64 info.G.file_downloaded) else (Int64.to_string info.G.file_downloaded))
+            (if !!html_mods_human_readable then (size_of_int64 info.G.file_size) else (Int64.to_string info.G.file_size)) ) ];
 
       Printf.bprintf buf "\\</tr\\>\\<tr class=\\\"dl-%d\\\"\\>" (html_mods_cntr ());
       html_mods_td buf [

--- a/src/daemon/common/commonFile.ml
+++ b/src/daemon/common/commonFile.ml
@@ -845,7 +845,8 @@ parent.fstatus.location.href='submit?q=chgrp+'+v+'+%d';
       html_mods_td buf [
         ("Chunk size", "sr br", "Chunk size");
         ("", "sr", (match info.G.file_chunk_size with
-          Some v -> String.concat " " (List.map (fun v -> Printf.sprintf "%Ld" v) v)
+          Some v -> String.concat " " (List.map (if !!html_mods_human_readable then
+            (fun v -> size_of_int64 v) else (fun v -> Int64.to_string v)) v)
         | None -> "unknown"))];
 
       (match file_magic file with

--- a/src/networks/bittorrent/bTInteractive.ml
+++ b/src/networks/bittorrent/bTInteractive.ml
@@ -354,7 +354,8 @@ let op_file_print file o =
   emit (_s"Creation date") (Date.to_string (Int64.to_float file.file_creation_date));
   emit (_s"Modified by") (match file.file_modified_by with "" -> "-" | s -> auto_links s);
   emit (_s"Encoding") (match file.file_encoding with "" -> "-" | s -> s);
-  emit (_s"Piece size") (Int64.to_string file.file_piece_size);
+  emit (_s"Piece size") (if !!html_mods_human_readable then
+    (size_of_int64 file.file_piece_size) else (Int64.to_string file.file_piece_size));
   emit (_s"Private") ~desc:(_s"Private torrents get peers only via trackers")
     (if file.file_private then _s "yes" else _s "no");
   if !bt_dht <> None then


### PR DESCRIPTION
Obey `html_mods_human_readable` setting for file size/downloaded bytes in file details (`vd NUM`). These sizes can be very big and become unreadable if displayed as bytes.

While at it, do the same for chunk and piece sizes (this also affects `print_torrent NUM`).